### PR TITLE
makefile options reset

### DIFF
--- a/JHUGenMELA/makefile
+++ b/JHUGenMELA/makefile
@@ -5,7 +5,7 @@ fcomp = ifort -fpp -O2 -vec-report0 -Dcompiler=1
 # fcomp = ifort -fpp -O0 -vec-report0 -Dcompiler=1
 endif
 ifeq ($(Comp),gfort)
-fcomp = gfortran -O3 -ffree-line-length-none -Dcompiler=2
+fcomp = f95 -O3 -ffree-line-length-none -Dcompiler=2
 endif
 
 ccomp = gcc

--- a/JHUGenerator/makefile
+++ b/JHUGenerator/makefile
@@ -6,7 +6,7 @@ VegasDir = $(Here)/vegas
 
 # compiler options, Comp=ifort/gfort
 Opt  = Yes
-Comp = ifort
+Comp = gfort
 
 
 


### PR DESCRIPTION
JHUGenerator/genps.c:
-inline void swapdbl_(double *r1, double *r2){
+void swapdbl_(double *r1, double *r2){ //"inline" taken out due to mac
error
